### PR TITLE
fixed version of dash.js for injectJs function in patcher.js

### DIFF
--- a/js/patcher.js
+++ b/js/patcher.js
@@ -321,7 +321,7 @@
         if (urlFound && tab.status === 'complete') { // page has been fully reloaded ... then inject JS simulator ...
             injectCss(tabId, 'css/injector.css', 'HbbTV CSS injection done.');
             //injectJs(tabId, 'https://cdn.jsdelivr.net/npm/mux.js@5.1.0/dist/mux-mp4.min.js', 'mux.js injection done.', true, false, 'async');
-            injectJs(tabId, 'https://cdn.dashjs.org/latest/dash.all.min.js', 'DASH.js injection done.', true, false, 'async');
+            injectJs(tabId, 'https://cdn.dashjs.org/v2.9.3/dash.all.min.js', 'DASH.js injection done.', true, false, 'async');
             injectJs(tabId, 'js/hbbobj.js', 'HbbTV OBJECT injection done.', true, false, 'async');
 
         } else if (urlFound === false && tab.status === 'complete') { // page not recognized but loaded then analyze internal meta tags ...


### PR DESCRIPTION
Hello Karl,

first of all, I would like to thank you for this extension. 

And now to the issue:

At the moment it is not possible to use the latest version of HybridTvViewer plugin from the https://github.com/karl-rousseau/HybridTvViewer because this plugin is corrupted now (10.02.2020).

The problem(s) are the dependencies, that this plugin is using now.

The HybridTvViewer plugin is using like the dependency the latest version of dash.js (the official reference player of the DASH Industry Forum) the latest version of dash.js is the version dash.js v3.0.2 

In the Version dash.js v3.0.0 (pull request #2954) were introduced breaking changes compared to the previous version dash.js v2.9.3.

The HybridTvViewer plugin is using the latest version of dash.js but was not adapted to use this last version.

If we take a look at the pacher.js (at the line 324) we can see that this inject the latest version of dash.js but in hbbobj.js (at the line 681) the old API from previous version is still used.

To resolve the issue with broken dash.js API in the current HybridTvViewer version this plugin must use the dash.js v2.9.3


References (links):
https://github.com/Dash-Industry-Forum/dash.js/pull/2954
https://github.com/Dash-Industry-Forum/dash.js/issues/3018